### PR TITLE
Add nightmode

### DIFF
--- a/esphome/components/mitsubishi/mitsubishi.cpp
+++ b/esphome/components/mitsubishi/mitsubishi.cpp
@@ -32,7 +32,6 @@ const uint8_t MITSUBISHI_POWERFUL = 0x08;
 // Optional presets used to enable some model features
 const uint8_t MITSUBISHI_ECONOCOOL = 0x20;
 const uint8_t MITSUBISHI_NIGHTMODE = 0xC1;
-const uint8_t MITSUBISHI_DEFAULTMODE = 0x81;
 
 // Pulse parameters in usec
 const uint16_t MITSUBISHI_BIT_MARK = 430;
@@ -378,9 +377,6 @@ bool MitsubishiClimate::on_receive(remote_base::RemoteReceiveData data) {
       break;
     case MITSUBISHI_NIGHTMODE:
       this->preset = climate::CLIMATE_PRESET_SLEEP;
-      break;
-    case MITSUBISHI_DEFAULTMODE:
-      this->preset = climate::CLIMATE_PRESET_NONE;
       break;
   }
 

--- a/esphome/components/mitsubishi/mitsubishi.cpp
+++ b/esphome/components/mitsubishi/mitsubishi.cpp
@@ -83,8 +83,8 @@ climate::ClimateTraits MitsubishiClimate::traits() {
   traits.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_BOTH,
                                     climate::CLIMATE_SWING_VERTICAL, climate::CLIMATE_SWING_HORIZONTAL});
 
-  traits.set_supported_presets(
-      {climate::CLIMATE_PRESET_NONE, climate::CLIMATE_PRESET_ECO, climate::CLIMATE_PRESET_BOOST, climate::CLIMATE_PRESET_SLEEP});
+  traits.set_supported_presets({climate::CLIMATE_PRESET_NONE, climate::CLIMATE_PRESET_ECO,
+                                climate::CLIMATE_PRESET_BOOST, climate::CLIMATE_PRESET_SLEEP});
 
   return traits;
 }

--- a/esphome/components/mitsubishi/mitsubishi.h
+++ b/esphome/components/mitsubishi/mitsubishi.h
@@ -48,7 +48,8 @@ class MitsubishiClimate : public climate_ir::ClimateIR {
              climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH, climate::CLIMATE_FAN_QUIET},
             {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_BOTH, climate::CLIMATE_SWING_VERTICAL,
              climate::CLIMATE_SWING_HORIZONTAL},
-            {climate::CLIMATE_PRESET_NONE, climate::CLIMATE_PRESET_ECO, climate::CLIMATE_PRESET_BOOST, climate::CLIMATE_PRESET_SLEEP}) {}
+            {climate::CLIMATE_PRESET_NONE, climate::CLIMATE_PRESET_ECO, climate::CLIMATE_PRESET_BOOST,
+             climate::CLIMATE_PRESET_SLEEP}) {}
 
   void set_supports_cool(bool supports_cool) { this->supports_cool_ = supports_cool; }
   void set_supports_dry(bool supports_dry) { this->supports_dry_ = supports_dry; }

--- a/esphome/components/mitsubishi/mitsubishi.h
+++ b/esphome/components/mitsubishi/mitsubishi.h
@@ -48,7 +48,7 @@ class MitsubishiClimate : public climate_ir::ClimateIR {
              climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH, climate::CLIMATE_FAN_QUIET},
             {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_BOTH, climate::CLIMATE_SWING_VERTICAL,
              climate::CLIMATE_SWING_HORIZONTAL},
-            {climate::CLIMATE_PRESET_NONE, climate::CLIMATE_PRESET_ECO, climate::CLIMATE_PRESET_BOOST}) {}
+            {climate::CLIMATE_PRESET_NONE, climate::CLIMATE_PRESET_ECO, climate::CLIMATE_PRESET_BOOST, climate::CLIMATE_PRESET_SLEEP}) {}
 
   void set_supports_cool(bool supports_cool) { this->supports_cool_ = supports_cool; }
   void set_supports_dry(bool supports_dry) { this->supports_dry_ = supports_dry; }


### PR DESCRIPTION
# What does this implement/fix?

Add support for night mode on the Mitsubishi.

I've been using your branch on my MSZ-AP units, and it's been great, thanks!

This change add support for night mode, using the climate mode SLEEP. Seems to work for me!

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

